### PR TITLE
feat: add break mode functionality to Pomodoro timer

### DIFF
--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 class AppConstants {
   // Timer constants
   static const int pomodoroDuration = 25 * 60; // 25 minutes in seconds
+  static const int breakDuration = 3 * 60; // 3 minutes in seconds
 
   // Celestial body properties
   static const double orbitRadius = 80.0;
@@ -13,6 +14,7 @@ class AppConstants {
   static const double celestialBodySize = 30.0;
   static const Color sunColor = Colors.red;
   static const Color planetColor = Colors.blue;
+  static const Color breakModePlanetColor = Colors.green;
   static const Color orbitColor = Colors.grey;
 
   // Animation constants

--- a/lib/screens/pomodoro_screen.dart
+++ b/lib/screens/pomodoro_screen.dart
@@ -6,6 +6,9 @@ import 'package:cosmic_pomo/widgets/orbital_animation.dart';
 import 'package:cosmic_pomo/widgets/timer_controls.dart';
 import 'package:flutter/material.dart';
 
+/// Represents the two modes of the Pomodoro timer
+enum PomodoroMode { work, breakMode }
+
 class PomodoroScreen extends StatefulWidget {
   const PomodoroScreen({super.key});
 
@@ -15,6 +18,8 @@ class PomodoroScreen extends StatefulWidget {
 
 class _PomodoroScreenState extends State<PomodoroScreen>
     with SingleTickerProviderStateMixin {
+  // Current mode of the timer
+  PomodoroMode _currentMode = PomodoroMode.work;
   int _remainingTime = AppConstants.pomodoroDuration;
   Timer? _timer;
 
@@ -28,7 +33,7 @@ class _PomodoroScreenState extends State<PomodoroScreen>
 
     // Initialize animation controller with the total timer duration
     _animationController = AnimationController(
-      duration: const Duration(seconds: AppConstants.pomodoroDuration),
+      duration: Duration(seconds: _getCurrentModeDuration()),
       vsync: this,
     );
 
@@ -46,13 +51,44 @@ class _PomodoroScreenState extends State<PomodoroScreen>
     super.dispose();
   }
 
+  /// Returns the duration in seconds for the current mode
+  int _getCurrentModeDuration() {
+    return _currentMode == PomodoroMode.work
+        ? AppConstants.pomodoroDuration
+        : AppConstants.breakDuration;
+  }
+
+  /// Returns a user-friendly name for the current mode
+  String _getCurrentModeName() {
+    return _currentMode == PomodoroMode.work ? 'Work' : 'Break Mode';
+  }
+
+  /// Toggles between work and break modes
+  void _toggleMode() {
+    setState(() {
+      _currentMode =
+          _currentMode == PomodoroMode.work
+              ? PomodoroMode.breakMode
+              : PomodoroMode.work;
+
+      // Reset timer for the new mode
+      _remainingTime = _getCurrentModeDuration();
+
+      // Reset animation controller duration
+      _animationController.duration = Duration(
+        seconds: _getCurrentModeDuration(),
+      );
+      _animationController.value = 0.0;
+    });
+  }
+
   void _startTimer() {
     if (_timer != null) {
       _timer!.cancel();
     }
 
     // Variables needed for syncing the timer and animation
-    final totalDuration = AppConstants.pomodoroDuration.toDouble();
+    final totalDuration = _getCurrentModeDuration().toDouble();
     final currentProgress = _remainingTime / totalDuration;
 
     // Start animation from current timer position
@@ -67,6 +103,10 @@ class _PomodoroScreenState extends State<PomodoroScreen>
           _animationController.value = 1.0 - (_remainingTime / totalDuration);
         } else {
           _timer!.cancel();
+          // Automatically switch to the next mode when timer completes
+          _toggleMode();
+          // Start the next timer automatically
+          _startTimer();
         }
       });
     });
@@ -81,7 +121,7 @@ class _PomodoroScreenState extends State<PomodoroScreen>
 
   void _resetTimer() {
     setState(() {
-      _remainingTime = AppConstants.pomodoroDuration;
+      _remainingTime = _getCurrentModeDuration();
       if (_timer != null) {
         _timer!.cancel();
       }
@@ -98,7 +138,7 @@ class _PomodoroScreenState extends State<PomodoroScreen>
 
       // Update timer based on new position
       final int newRemainingTime =
-          (AppConstants.pomodoroDuration * (1.0 - progressValue)).round();
+          (_getCurrentModeDuration() * (1.0 - progressValue)).round();
       _remainingTime = newRemainingTime;
 
       if (_timer != null) {
@@ -110,6 +150,11 @@ class _PomodoroScreenState extends State<PomodoroScreen>
 
   @override
   Widget build(BuildContext context) {
+    final Color modeColor =
+        _currentMode == PomodoroMode.work
+            ? AppConstants.planetColor
+            : AppConstants.breakModePlanetColor;
+
     return Scaffold(
       body: Container(
         decoration: const BoxDecoration(
@@ -127,33 +172,48 @@ class _PomodoroScreenState extends State<PomodoroScreen>
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              const SizedBox(height: AppConstants.standardSpacing),
+              const SizedBox(height: AppConstants.standardSpacing / 2),
+              Text(
+                '${_getCurrentModeName()} Mode',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: modeColor,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
               Text(
                 'Pomodoro Timer',
-                style:
-                    Theme.of(
-                      context,
-                    ).textTheme.headlineMedium?.copyWith(color: Colors.white) ??
-                    TextStyle(color: Colors.white),
+                style: Theme.of(
+                  context,
+                ).textTheme.headlineMedium?.copyWith(color: Colors.white),
               ),
               Text(
                 TimeFormatter.formatTime(_remainingTime),
-                style:
-                    Theme.of(
-                      context,
-                    ).textTheme.headlineMedium?.copyWith(color: Colors.white) ??
-                    TextStyle(color: Colors.white),
+                style: Theme.of(
+                  context,
+                ).textTheme.headlineMedium?.copyWith(color: Colors.white),
               ),
               const SizedBox(height: AppConstants.standardSpacing),
               OrbitalAnimation(
                 animation: _animation,
                 onPlanetDragged: _updateTimerFromPlanetPosition,
+                planetColor: modeColor,
               ),
               const SizedBox(height: AppConstants.standardSpacing),
               TimerControls(
                 onStart: _startTimer,
                 onStop: _stopTimer,
                 onReset: _resetTimer,
+              ),
+              TextButton(
+                onPressed: () {
+                  _stopTimer();
+                  _toggleMode();
+                  _resetTimer();
+                },
+                child: Text(
+                  'Switch to ${_currentMode == PomodoroMode.work ? 'Break Mode' : 'Work'} Mode',
+                  style: TextStyle(color: modeColor),
+                ),
               ),
             ],
           ),

--- a/lib/widgets/orbital_animation.dart
+++ b/lib/widgets/orbital_animation.dart
@@ -10,10 +10,12 @@ class OrbitalAnimation extends StatelessWidget {
     super.key,
     required this.animation,
     required this.onPlanetDragged,
+    required this.planetColor,
   });
 
   final Animation<double> animation;
   final void Function(double) onPlanetDragged;
+  final Color planetColor;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
- Introduced break duration constant in AppConstants.
- Added PomodoroMode enum to represent work and break modes.
- Implemented mode toggling logic in PomodoroScreen.
- Updated timer duration based on the current mode.
- Enhanced UI to display current mode and added a button to switch modes.
- Passed planet color based on the current mode to OrbitalAnimation.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能: ポモドーロタイマーにブレークモードが追加され、作業と休憩の切り替えが可能になりました。
- 新機能: 現在のモードを表示するUIが強化され、モード切り替えボタンが追加されました。
- 新機能: アニメーションに使用される惑星の色が、現在のモードに基づいて変更されるようになりました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->